### PR TITLE
Removed Web API configuration classes from test coverage

### DIFF
--- a/src/Lewee.Infrastructure.AspNet.WebApi/ControllerConfiguration.cs
+++ b/src/Lewee.Infrastructure.AspNet.WebApi/ControllerConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Lewee.Infrastructure.AspNet.WebApi;
@@ -13,6 +14,7 @@ public static class ControllerConfiguration
     /// </summary>
     /// <param name="services">Services collection</param>
     /// <returns>Updated services collection</returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection ConfigureControllers(this IServiceCollection services)
     {
         services

--- a/src/Lewee.Infrastructure.AspNet.WebApi/CorsConfiguration.cs
+++ b/src/Lewee.Infrastructure.AspNet.WebApi/CorsConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Lewee.Infrastructure.AspNet.WebApi;
 
@@ -12,6 +13,7 @@ public static class CorsConfiguration
     /// </summary>
     /// <param name="services">Services collection</param>
     /// <param name="allowedOrigins">Semicolon-separated list of allowed origins</param>
+    [ExcludeFromCodeCoverage]
     public static void ConfigureCorsDefaultPolicy(this IServiceCollection services, string allowedOrigins)
     {
         services.AddCors(options => options.AddDefaultPolicy(policyBuilder =>


### PR DESCRIPTION
The following classes are not used in the sample app because the sample is optimized for Blazor
- `ControllerConfiguration`
- `CorsConfiguration`