### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,3 +1,5 @@
+name: Build & Test
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   buildAndTest:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,9 @@ on:
         required: false
         type: boolean
 
+permissions:
+  contents: write
+
 jobs:
   buildAndTest:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [ develop, main ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   buildAndTest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Continuous Integration
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
     branches: [ develop, main ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   buildAndTest:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main, develop ]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   buildAndTest:
     uses: ./.github/workflows/build-and-test.yml

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,8 @@ on:
     branches: [ main, develop ]
 
 permissions:
-  contents: write
+  contents: read
+  pull-requests: write
 
 jobs:
   buildAndTest:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main, develop ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   buildAndTest:


### PR DESCRIPTION
Potential fix for [https://github.com/TheMagnificent11/lewee/security/code-scanning/3](https://github.com/TheMagnificent11/lewee/security/code-scanning/3)

To fix the problem, explicitly declare a `permissions:` block in this workflow so that the GITHUB_TOKEN is restricted according to the principle of least privilege, instead of inheriting potentially broad repository/organization defaults.

The best minimal change that does not alter existing functional behavior is to add a top-level `permissions:` block (applies to all jobs) right after the `on:` trigger. For a typical PR checks workflow that only needs to fetch code and run checks, `contents: read` is sufficient. If the called workflow needs additional scopes (e.g., to update PR statuses or comments), those should be added in that file; here we’ll add the safe minimal `contents: read`. Concretely, in `.github/workflows/pr-checks.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–5) and the `jobs:` block (line 7). No imports or additional methods are needed, as this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
