### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ develop, main ]
 
+permissions:
+  contents: read
+
 jobs:
   buildAndTest:
     uses: ./.github/workflows/build-and-test.yml


### PR DESCRIPTION
Potential fix for [https://github.com/TheMagnificent11/lewee/security/code-scanning/1](https://github.com/TheMagnificent11/lewee/security/code-scanning/1)

In general, to fix this issue you add a `permissions` block either at the top level of the workflow (so it applies to all jobs by default) or on the specific job that is missing it. The `permissions` block should restrict the `GITHUB_TOKEN` to the least privileges required, commonly `contents: read` for basic CI tasks that only need to fetch code and report status.

For this specific workflow, the simplest and least invasive fix that doesn’t change behavior is to add a top-level `permissions` block between the `on:` block and the `jobs:` block. A conservative, widely recommended minimal set is `contents: read`, which allows the workflow to check out the repository and read contents but not modify them. If the called workflow needs more granular permissions, it can still override this, but adding this root-level block ensures that, by default, jobs use restricted permissions. You only need to modify `.github/workflows/ci.yml` to insert this block; no imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
